### PR TITLE
Fix/hand controller serializer initialization

### DIFF
--- a/Assets/Resources/OculusPlatformSettings.asset.meta
+++ b/Assets/Resources/OculusPlatformSettings.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7aa9eecd8b4d21f47a0eb10164327010
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Virtual Reality and Visualization Research Group @ Bauhaus-Universität Weimar
+(www.uni-weimar.de/vr)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packages/com.vrsys.core/Runtime/Scripts/Avatar/AvatarHMDAnatomy.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Avatar/AvatarHMDAnatomy.cs
@@ -108,8 +108,8 @@ namespace VRSYS.Core.Avatar
 
         private void MotionControllersDeactivated()
         {
-            leftHand = null;
-            rightHand = null;
+            leftHand = _defaultLeftHand;
+            rightHand = _defaultRightHand;
         }
 
         private void TrackedHandsActivated()
@@ -120,8 +120,8 @@ namespace VRSYS.Core.Avatar
 
         private void TrackedHandsDeactivated()
         {
-            leftHand = null;
-            rightHand = null;
+            leftHand = _defaultLeftHand;
+            rightHand = _defaultRightHand;
         }
 
         #endregion

--- a/Packages/com.vrsys.core/Runtime/Scripts/Avatar/ControllerAnimatorSerializer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Avatar/ControllerAnimatorSerializer.cs
@@ -36,6 +36,7 @@
 //   Date:           2026
 //-----------------------------------------------------------------
 
+using System.Collections;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit.Inputs;
@@ -92,6 +93,8 @@ namespace VRSYS.Core.Avatar
                     _modalityManager.motionControllerModeEnded.AddListener(OnControllerModeEnded);
                     _modalityManager.trackedHandModeStarted.AddListener(OnTrackedHandModeStarted);
                 }
+
+                StartCoroutine(ActiveStateSanityCheck());
             }
             else
             {
@@ -144,6 +147,21 @@ namespace VRSYS.Core.Avatar
         private void OnTrackedHandModeStarted() => _isActive.Value = false;
 
         private void OnisActiveChanged(bool previousValue, bool newValue) => UpdateControllerVisualsActive();
+
+        #endregion
+
+        #region Coroutines
+
+        private IEnumerator ActiveStateSanityCheck()
+        {
+            while (true)
+            {
+                if (_isActive.Value != _controller.activeSelf)
+                    _isActive.Value = _controller.activeSelf;
+
+                yield return new WaitForSeconds(1f);
+            }
+        }
 
         #endregion
     }

--- a/Packages/com.vrsys.core/Runtime/Scripts/Avatar/ControllerAnimatorSerializer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Avatar/ControllerAnimatorSerializer.cs
@@ -60,7 +60,7 @@ namespace VRSYS.Core.Avatar
 
         #region Network Properties
 
-        private NetworkVariable<bool> _isActive = new(false, NetworkVariableReadPermission.Everyone,
+        private NetworkVariable<bool> _isActive = new(true, NetworkVariableReadPermission.Everyone,
             NetworkVariableWritePermission.Owner);
 
         private NetworkVariable<ControllerAnimator.ControllerValueData> _controllerValueData =
@@ -90,6 +90,7 @@ namespace VRSYS.Core.Avatar
                 {
                     _modalityManager.motionControllerModeStarted.AddListener(OnControllerModeStarted);
                     _modalityManager.motionControllerModeEnded.AddListener(OnControllerModeEnded);
+                    _modalityManager.trackedHandModeStarted.AddListener(OnTrackedHandModeStarted);
                 }
             }
             else
@@ -139,6 +140,8 @@ namespace VRSYS.Core.Avatar
         private void OnControllerModeStarted() => _isActive.Value = true;
 
         private void OnControllerModeEnded() => _isActive.Value = false;
+
+        private void OnTrackedHandModeStarted() => _isActive.Value = false;
 
         private void OnisActiveChanged(bool previousValue, bool newValue) => UpdateControllerVisualsActive();
 

--- a/Packages/com.vrsys.core/Runtime/Scripts/Avatar/TrackedHandSerializer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Avatar/TrackedHandSerializer.cs
@@ -141,7 +141,7 @@ namespace VRSYS.Core.Avatar
 
         private NetworkVariable<bool> _initialized = new(false, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
-        private NetworkVariable<bool> _isActive = new(false, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
+        private NetworkVariable<bool> _isActive = new(true, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
         private NetworkVariable<Vector3> _rootPosition = new(Vector3.zero, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Owner);
 
@@ -165,15 +165,16 @@ namespace VRSYS.Core.Avatar
         {
             if (IsOwner)
             {
-                InitializeNetworkProperties();
-
                 _modalityManager = GetComponentInParent<XRInputModalityManager>();
 
                 if (_modalityManager != null)
                 {
                     _modalityManager.trackedHandModeStarted.AddListener(OnTrackedHandModeStarted);
                     _modalityManager.trackedHandModeEnded.AddListener(OnTrackedHandModeEnded);
+                    _modalityManager.motionControllerModeStarted.AddListener(OnControllerModeStarted);
                 }
+
+                InitializeNetworkProperties();
             }
             else
             {
@@ -471,6 +472,8 @@ namespace VRSYS.Core.Avatar
         private void OnTrackedHandModeStarted() => _isActive.Value = true;
 
         private void OnTrackedHandModeEnded() => _isActive.Value = false;
+
+        private void OnControllerModeStarted() => _isActive.Value = false;
 
         private void OnIsActiveChanged(bool previousValue, bool newValue) => UpdateHandVisualsActive();
 

--- a/Packages/com.vrsys.core/Runtime/Scripts/Avatar/TrackedHandSerializer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Avatar/TrackedHandSerializer.cs
@@ -37,6 +37,7 @@
 //-----------------------------------------------------------------
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Unity.Netcode;
 using UnityEngine;
@@ -175,6 +176,8 @@ namespace VRSYS.Core.Avatar
                 }
 
                 InitializeNetworkProperties();
+
+                StartCoroutine(ActiveStateSanityCheck());
             }
             else
             {
@@ -476,6 +479,21 @@ namespace VRSYS.Core.Avatar
         private void OnControllerModeStarted() => _isActive.Value = false;
 
         private void OnIsActiveChanged(bool previousValue, bool newValue) => UpdateHandVisualsActive();
+
+        #endregion
+
+        #region Coroutines
+
+        private IEnumerator ActiveStateSanityCheck()
+        {
+            while (true)
+            {
+                if (_isActive.Value != _hand.activeSelf)
+                    _isActive.Value = _hand.activeSelf;
+
+                yield return new WaitForSeconds(1f);
+            }
+        }
 
         #endregion
     }

--- a/Packages/com.vrsys.core/Runtime/Scripts/Avatar/UserNameLabel.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Avatar/UserNameLabel.cs
@@ -98,7 +98,7 @@ namespace VRSYS.Core.Avatar
             if(_labelText != null)
                 _labelText.text = userName;
             
-            if(_iconText != null)
+            if(_iconText != null && !string.IsNullOrEmpty(userName))
                 _iconText.text = userName[0].ToString();
         }
 

--- a/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
@@ -61,7 +61,7 @@ namespace VRSYS.Core.Logging
             }
         }
 
-        private bool _canLog => !NetworkManager.Singleton.ShutdownInProgress && NetworkManager.IsConnectedClient;
+        private bool _canLog => NetworkManager.Singleton != null && !NetworkManager.Singleton.ShutdownInProgress && NetworkManager.IsConnectedClient;
         
         #endregion
 

--- a/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
@@ -46,8 +46,8 @@ namespace VRSYS.Core.Logging
     {
         #region Member Variables
 
-        [SerializeField] private LogLevel _logLevel;
-        [SerializeField] private bool _printAllLogs;
+        [SerializeField] private LogLevel _logLevel = LogLevel.Info;
+        [SerializeField] private bool _printAllLogs = false;
 
         private string _logTag
         {

--- a/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
@@ -47,6 +47,7 @@ namespace VRSYS.Core.Logging
         #region Member Variables
 
         [SerializeField] private LogLevel _logLevel;
+        [SerializeField] private bool _printAllLogs;
 
         private string _logTag
         {
@@ -71,6 +72,9 @@ namespace VRSYS.Core.Logging
             ExtendedLogger.OnInfoLog.AddListener(LogInfo);
             ExtendedLogger.OnWarningLog.AddListener(LogWarning);
             ExtendedLogger.OnErrorLog.AddListener(LogError);
+
+            if(_printAllLogs)
+                Application.logMessageReceived += OnUnityLogReceived;
         }
 
         public override void OnNetworkDespawn()
@@ -87,34 +91,62 @@ namespace VRSYS.Core.Logging
 
         #region Private Methods
 
-        private void LogInfo(ExtendedLoggerLogInformation logInfo)
+        private void LogInfo(ExtendedLoggerLogInformation logInfo) => LogInfo(logInfo.FormattedMessage);
+
+        private void LogInfo(string message)
         {
             if (_logLevel < LogLevel.Warning)
             {
-                string log = _logTag + logInfo.FormattedMessage;
+                string log = _logTag + message;
                 LogInfoRpc(log);
             }
         }
 
-        private void LogWarning(ExtendedLoggerLogInformation logInfo)
+        private void LogWarning(ExtendedLoggerLogInformation logInfo) => LogWarning(logInfo.FormattedMessage);
+
+        private void LogWarning(string message)
         {
             if (_logLevel < LogLevel.Error)
             {
-                string log = _logTag + logInfo.FormattedMessage;
+                string log = _logTag + message;
                 LogWarningRpc(log);
             }
         }
 
-        private void LogError(ExtendedLoggerLogInformation logInfo)
+        private void LogError(ExtendedLoggerLogInformation logInfo) => LogError(logInfo.FormattedMessage);
+
+        private void LogError(string message)
         {
             if (_logLevel < LogLevel.None)
             {
-                string log = _logTag + logInfo.FormattedMessage;
+                string log = _logTag + message;
                 
                 LogErrorRpc(log);
             }
         }
-
+        
+        private void OnUnityLogReceived(string condition, string stacktrace, LogType type)
+        {
+            switch (type)
+            {
+                case LogType.Log:
+                    LogInfo(condition);
+                    break;
+                case LogType.Warning:
+                    LogWarning(condition);
+                    break;
+                case LogType.Error:
+                    LogError(condition + "\n" + stacktrace);
+                    break;
+                case LogType.Exception:
+                    LogError(condition + "\n" + stacktrace);
+                    break;
+                default:
+                    LogInfo(condition + "\n" + stacktrace);
+                    break;
+            }
+        }
+        
         #endregion
 
         #region RPCs

--- a/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Logging/ExtendedLoggerToServer.cs
@@ -38,6 +38,7 @@
 
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.Serialization;
 using VRSYS.Core.Networking;
 
 namespace VRSYS.Core.Logging
@@ -47,7 +48,7 @@ namespace VRSYS.Core.Logging
         #region Member Variables
 
         [SerializeField] private LogLevel _logLevel = LogLevel.Info;
-        [SerializeField] private bool _printAllLogs = false;
+        [SerializeField] private bool _printUnityLogs = false;
 
         private string _logTag
         {
@@ -59,6 +60,8 @@ namespace VRSYS.Core.Logging
                 return $"<color=white>[<color=purple>Client {NetworkManager.LocalClientId}</color>]</color>";
             }
         }
+
+        private bool _canLog => !NetworkManager.Singleton.ShutdownInProgress && NetworkManager.IsConnectedClient;
         
         #endregion
 
@@ -73,7 +76,7 @@ namespace VRSYS.Core.Logging
             ExtendedLogger.OnWarningLog.AddListener(LogWarning);
             ExtendedLogger.OnErrorLog.AddListener(LogError);
 
-            if(_printAllLogs)
+            if(_printUnityLogs)
                 Application.logMessageReceived += OnUnityLogReceived;
         }
 
@@ -95,6 +98,9 @@ namespace VRSYS.Core.Logging
 
         private void LogInfo(string message)
         {
+            if(!_canLog)
+                return;
+            
             if (_logLevel < LogLevel.Warning)
             {
                 string log = _logTag + message;
@@ -106,6 +112,9 @@ namespace VRSYS.Core.Logging
 
         private void LogWarning(string message)
         {
+            if(!_canLog)
+                return;
+            
             if (_logLevel < LogLevel.Error)
             {
                 string log = _logTag + message;
@@ -117,6 +126,9 @@ namespace VRSYS.Core.Logging
 
         private void LogError(string message)
         {
+            if(!_canLog)
+                return;
+            
             if (_logLevel < LogLevel.None)
             {
                 string log = _logTag + message;

--- a/Packages/com.vrsys.core/Runtime/Scripts/Navigation/ThumbstickNavigation.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Navigation/ThumbstickNavigation.cs
@@ -138,9 +138,10 @@ namespace VRSYS.Core.Navigation
         private bool initialized = false;
         
         // Variables related to determining steering/teleportation direction
-        private Transform head;
-        private Transform leftHand;
-        private Transform rightHand;
+        private AvatarHMDAnatomy _anatomy;
+        private Transform head => _anatomy.head;
+        private Transform leftHand => _anatomy.leftHand;
+        private Transform rightHand => _anatomy.rightHand;
 
         private Transform forwardIndicator
         {
@@ -238,9 +239,9 @@ namespace VRSYS.Core.Navigation
 
         private void Initialize()
         {
-            AvatarHMDAnatomy anatomy = GetComponent<AvatarHMDAnatomy>();
+            _anatomy = GetComponent<AvatarHMDAnatomy>();
             
-            if (anatomy == null)
+            if (_anatomy == null)
             {
                 ExtendedLogger.LogError(GetType().Name, "This component has to be attached to the root of a HMD user with a NetworkUser and AvatarHMDAnatomy component.", this);
                 return;
@@ -254,10 +255,6 @@ namespace VRSYS.Core.Navigation
 
             if (rotationReference == null)
                 rotationReference = transform;
-            
-            head = anatomy.head;
-            leftHand = anatomy.leftHand;
-            rightHand = anatomy.rightHand;
 
             initialized = true;
         }

--- a/Packages/com.vrsys.core/Runtime/Scripts/Navigation/ThumbstickNavigation.cs
+++ b/Packages/com.vrsys.core/Runtime/Scripts/Navigation/ThumbstickNavigation.cs
@@ -178,7 +178,7 @@ namespace VRSYS.Core.Navigation
                         direction = navigationHand == HandType.Left ? leftHand.forward : rightHand.forward;
                         break;
                 }
-
+                
                 if (!verticalSteering)
                     direction.y = 0f;
                 
@@ -268,7 +268,7 @@ namespace VRSYS.Core.Navigation
             Vector2 input = navigationHand == HandType.Left
                 ? leftThumbstick.action.ReadValue<Vector2>()
                 : rightThumbstick.action.ReadValue<Vector2>();
-
+            
             Vector3 direction = GetSteeringDirection(input);
 
             steeringTarget.position += direction * (steeringSpeed * input.magnitude * Time.deltaTime);

--- a/Packages/com.vrsys.core/Samples~/Hand Tracking and Animated Controller Samples/Scene/VRSYS-HandTracking.unity
+++ b/Packages/com.vrsys.core/Samples~/Hand Tracking and Animated Controller Samples/Scene/VRSYS-HandTracking.unity
@@ -1816,6 +1816,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: VRSYS-ExtendedLoggerToServer
       objectReference: {fileID: 0}
+    - target: {fileID: 6968346195853434940, guid: c2931169575e1aa47a0d8d1c5fa91c8d, type: 3}
+      propertyPath: _printAllLogs
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6968346195853434940, guid: c2931169575e1aa47a0d8d1c5fa91c8d, type: 3}
+      propertyPath: _printUnityLogs
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Packages/com.vrsys.core/package.json
+++ b/Packages/com.vrsys.core/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "com.vrsys.core",
-  "version" : "1.0.8",
+  "version" : "1.0.9",
   "displayName" : "VRSYS Core",
   "description": "Core elements of VRSYS framework.",
   "documentationUrl" : "https://vrsys.gitbook.io/vrsys",


### PR DESCRIPTION
**VRSYS Core v1.0.9**

**Features:**

- ExtendedLoggerToServer: now allows to print all Unity logs to Server, can be enabled or disabled in inspector via _printAllLogs —> if false, only ExtendedLogger logs will be distributed. Unity logs are also affected by _logLevel configured on ExtendedLoggerToServer.

**Fixes:**

- Animated Controllers and Hand Tracking: Fixed bug, where both visuals could be activated on remote clients when joining the scene
- UserNameLabel: Catch for potential null ref, if user name still null
- Thumbstick Navigation: Adapted to refactored AvatarHMDAnatomy, where left and right hand references can change dynamically on runtime
- AvatarHMDAnatomy: If neither  controllers or tracked hands are active —> fallback to default references
- ExtendedLoggerToServer: Fixed null refs when leaving network session